### PR TITLE
Fix issues compiling on Ubuntu 20.04

### DIFF
--- a/Code.v05-00/src/Core/Engine.cpp
+++ b/Code.v05-00/src/Core/Engine.cpp
@@ -36,7 +36,7 @@ Engine::Engine( const char *engineName, double tempe_K, double pres_Pa, double r
     foundEngine = GetEDB( engineFile, engineName, idle, approach, climbout, takeoff );
     
     if ( foundEngine == 0 ) {
-        std::cout << "Engine " << engineName << " was not found in " << engineFileName << std::cout;
+        std::cout << "Engine " << engineName << " was not found in " << engineFileName << std::endl;
         return;
     }
 

--- a/Code.v05-00/src/Core/Makefile
+++ b/Code.v05-00/src/Core/Makefile
@@ -84,9 +84,9 @@ TARGET     := APCEMM.sh
 .PHONY: libUtil libKpp libSands libAim libEpm libCore
 
 all:
-	@$(MAKE) $(MAKEFLAGS) build
-	@$(MAKE) $(MAKEFLAGS) lib
-	@$(MAKE) $(MAKEFLAGS) exe
+	@$(MAKE) build
+	@$(MAKE) lib
+	@$(MAKE) exe
 
 build:
 	@mkdir -p $(LIB_DIR)
@@ -112,7 +112,7 @@ libUtil:
 
 libKpp:
 	@$(MAKE) -C $(KPP_DIR)
-	
+
 libSands:
 	@$(MAKE) -C $(SANDS_DIR)
 

--- a/Code.v05-00/src/EPM/odeSolver.cpp
+++ b/Code.v05-00/src/EPM/odeSolver.cpp
@@ -372,8 +372,6 @@ namespace EPM
     } /* End of streamingObserver::checkwatersat */
 
     template class odeSolver<void ( const Vector_1D&, Vector_1D&, RealDouble )>;
-    template class odeSolver<void ( const Vector_1D&, Vector_1D&, RealDouble ) const>;
-
 }
 
 /* End of odeSolver.cpp */

--- a/Code.v05-00/src/SANDS/FFT.cpp
+++ b/Code.v05-00/src/SANDS/FFT.cpp
@@ -12,6 +12,7 @@
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
 
 #include "SANDS/FFT.hpp"
+#include "omp.h"
 
 FourierTransform_1D<float>::FourierTransform_1D( const bool MULTITHREADED_FFT, \
                                                  const bool WISDOM,            \


### PR DESCRIPTION
* Fix Makefile to work newer versions of make
* Remove invalid template instantiation for class odeSolver that was causing confusing compiler errors
* Fix missing include of omp.h
* Fix typo in Engine.cpp that was causing a compilation error