### PR TITLE
Fix memory errors identified by valgrind

### DIFF
--- a/Code.v05-00/src/AIM/Aerosol.cpp
+++ b/Code.v05-00/src/AIM/Aerosol.cpp
@@ -1839,7 +1839,7 @@ namespace AIM
     {
 
         Vector_2D TotalNumber_pcell = TotalNumber( );
-        RealDouble totalnumber_sum;
+        RealDouble totalnumber_sum = 0;
         UInt iNx = 0;
         UInt jNy = 0;
 
@@ -1944,8 +1944,8 @@ namespace AIM
     {
 
         Vector_2D TotalVolume_pcell = TotalVolume( );
-        RealDouble totalvolume_sum;
-        RealDouble totalicemass_sum;
+        RealDouble totalvolume_sum = 0;
+        RealDouble totalicemass_sum = 0;
         UInt iNx = 0;
         UInt jNy = 0;
 

--- a/Code.v05-00/src/Core/Diag_Mod.cpp
+++ b/Code.v05-00/src/Core/Diag_Mod.cpp
@@ -139,6 +139,7 @@ bool Diag_TS_Chem( const char* rootName,                     \
                                                  outputType, (const char*)charUnit, \
                                                  (const char*)charName );
                     }
+                    delete[] array;
 
                 } else {
                     std::cout << " In Diag_Mod for timeseries: Unexpected index: " << speciesIndices[i] << std::endl;
@@ -147,8 +148,6 @@ bool Diag_TS_Chem( const char* rootName,                     \
             }
 
         }
-
-        delete[] array; array = NULL;
 
         if ( didSaveSucceed == NC_SUCCESS ) {
 //            std::cout << " Done saving to netCDF!" << "\n";
@@ -303,6 +302,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                      (const char*)charUnit,             \
                                      (const char*)charName );
         }
+        delete[] array;
 
         /* Saving meteorological temperature */
 
@@ -324,6 +324,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                      (const char*)charUnit,             \
                                      (const char*)charName );
         }
+        delete[] array;
 
         /* Saving H2O gaseous concentration */
 
@@ -345,7 +346,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                      (const char*)charUnit,             \
                                      (const char*)charName );
         }
-
+        delete[] array;
 
         if ( outputPDF == 2 ) {
 
@@ -372,6 +373,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,             \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving ice aerosol bin centers.
              * A moving bin structure is adopted in APCEMM. Each grid-cell thus 
@@ -396,6 +398,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,             \
                                          (const char*)charName );
             }
+            delete[] array;
 
         } else if ( outputPDF == 1 ) {
 
@@ -419,6 +422,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,             \
                                          (const char*)charName );
             }
+            delete[] array;
 
         } else {
 
@@ -446,6 +450,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving ice aerosol volume
              * Size: NY x NX */
@@ -468,6 +473,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving ice aerosol effective radius
              * Size: NY x NX */
@@ -490,6 +496,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving horizontal optical depth
              * Size: NY */
@@ -512,6 +519,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving vertical optical depth
              * Size: NX */
@@ -534,6 +542,7 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
             /* Saving overall size distributionh
              * Size: NX */
@@ -556,10 +565,9 @@ bool Diag_TS_Phys( const char* rootName,                     \
                                          (const char*)charUnit,            \
                                          (const char*)charName );
             }
+            delete[] array;
 
         }
-
-        delete[] array; array = NULL;
 
     }
 


### PR DESCRIPTION
* Fixes memory leaks in preparing output for netCDF where the memory allocated by `util::vect2float` was not being freed.
* Fix use of unintialized values when calculating total ice mass and total particle number